### PR TITLE
Add support for arm64 (Apple Silicon) Macs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ endif
 
 
 TOP_DEPS := wordfreq
-PLATFORMS := win_amd64 manylinux2014_x86_64 macosx_10_13_x86_64
+PLATFORMS := win_amd64 manylinux2014_x86_64 macosx_10_13_x86_64 macosx_11_0_arm64
 CALL_GFD := "scripts/get_full_deps.sh"
 CALL_MV := "scripts/make_vendor.sh"
 CALL_FMD := "scripts/fix_mecab_dll.sh"


### PR DESCRIPTION
I just was trying to use this plugin for Anki on my M1 Mac and the plugin crashed on startup. I added the `macosx_11_0_arm64` platform (and changed some build scripts locally) and everything worked fine. I was able to add the wordfreq as expected to my deck using my local build. 

Thanks for this plugin!